### PR TITLE
Treat files with `.yml` file extension as YAML

### DIFF
--- a/commands/util.js
+++ b/commands/util.js
@@ -31,12 +31,17 @@ function getFiles(args) {
     }
 }
 
+function getFormatFromFileName(filename) {
+    var format = path.extname(filename).substr(1).toLowerCase();
+    return format === 'yml' ? 'yaml' : format;
+}
+
 
 function openFile(filename, suffix){
     var file = path.resolve(process.cwd(), filename);
     try {
         var contents = fs.readFileSync(file).toString();
-        var format = path.extname(filename).substr(1).toLowerCase();
+        var format = getFormatFromFileName(filename);
         return wait(anyjson.decode(contents, format));
     } catch(err) {
         console.error('error:  ' + err.message.replace(' module', ' ' + suffix));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pajv",
   "displayName": "Polyglottal JSON Schema Validator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A command line JSON Schema validator that supports many file formats. Fork of jessedc/ajv-cli.",
   "scripts": {
     "eslint": "eslint index.js commands/*.js test/*.js test/**/*.js",

--- a/test/valid_data.yml
+++ b/test/valid_data.yml
@@ -1,0 +1,23 @@
+- id: 2
+  name: An ice sculpture
+  price: 12.5
+  tags:
+    - cold
+    - ice
+  dimensions:
+    length: 7
+    width: 12
+    height: 9.5
+  warehouseLocation:
+    latitude: -78.75
+    longitude: 20.4
+- id: 3
+  name: A blue mouse
+  price: 25.5
+  dimensions:
+    length: 3.1
+    width: 1
+    height: 1
+  warehouseLocation:
+    latitude: 54.4
+    longitude: -32.7

--- a/test/validate.spec.js
+++ b/test/validate.spec.js
@@ -17,6 +17,15 @@ describe('validate', function() {
       });
     });
 
+    it('should validate valid data with "yml" extension', function (done) {
+      cli('-s test/schema.json -d test/valid_data.yml', function (error, stdout, stderr) {
+        assert.strictEqual(error, null);
+        assertValid(stdout, 1);
+        assert.equal(stderr, '');
+        done();
+      });
+    });
+
     it('should validate invalid data', function (done) {
       cli('-s test/schema.json -d test/invalid_data.json --errors=line', function (error, stdout, stderr) {
         assert(error instanceof Error);


### PR DESCRIPTION
Treat files with `.yml` file extension as YAML.  Fixes #3.